### PR TITLE
Fix for linux low latency mode issue #2240 (revised)

### DIFF
--- a/packages/bindings/src/serialport_linux.cpp
+++ b/packages/bindings/src/serialport_linux.cpp
@@ -43,6 +43,8 @@ int linuxSetLowLatencyMode(const int fd, const bool enable) {
   if (ioctl(fd, TIOCGSERIAL, &ss)) {
     return -1;
   }
+  
+  int oldFlags = ss.flags;
 
   if (enable) {
     ss.flags |= ASYNC_LOW_LATENCY;
@@ -50,9 +52,24 @@ int linuxSetLowLatencyMode(const int fd, const bool enable) {
     ss.flags &= ~ASYNC_LOW_LATENCY;
   }
 
-  if (ioctl(fd, TIOCSSERIAL, &ss)) {
-    return -2;
+  if (oldFlags != ss.flags)
+  {
+    if (ioctl(fd, TIOCSSERIAL, &ss)) {
+      return -2;
+    }
   }
+
+  return 0;
+}
+
+int linuxGetLowLatencyMode(const int fd, bool* const enabled) {
+  struct serial_struct ss;
+
+  if (ioctl(fd, TIOCGSERIAL, &ss)) {
+    return -1;
+  }
+
+  *enabled = ss.flags & ASYNC_LOW_LATENCY;
 
   return 0;
 }

--- a/packages/bindings/src/serialport_linux.h
+++ b/packages/bindings/src/serialport_linux.h
@@ -4,6 +4,7 @@
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate);
 int linuxGetSystemBaudRate(const int fd, int* const outbaud);
 int linuxSetLowLatencyMode(const int fd, const bool enable);
+int linuxGetLowLatencyMode(const int fd, bool* const enabled);
 
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_LINUX_H_
 

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -352,10 +352,10 @@ void EIO_Set(uv_work_t* req) {
   #if defined(__linux__)
   int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
   if (err == -1) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get low latency", strerror(errno));
     return;
   } else if(err == -2) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set low latency", strerror(errno));
     return;
 }
   #endif

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -332,19 +332,6 @@ void EIO_Set(uv_work_t* req) {
     bits |= TIOCM_DSR;
   }
 
-  #if defined(__linux__)
-  if (data->lowLatency) {
-    int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
-    if (err == -1) {
-      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
-      return;
-    } else if(err == -2) {
-      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
-      return;
-    }
-  }
-  #endif
-
   int result = 0;
   if (data->brk) {
     result = ioctl(data->fd, TIOCSBRK, NULL);
@@ -361,6 +348,17 @@ void EIO_Set(uv_work_t* req) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
     return;
   }
+
+  #if defined(__linux__)
+  int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
+  if (err == -1) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
+    return;
+  } else if(err == -2) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
+    return;
+}
+  #endif
 }
 
 void EIO_Get(uv_work_t* req) {
@@ -372,19 +370,20 @@ void EIO_Get(uv_work_t* req) {
     return;
   }
 
-  data->lowLatency = false;
-  #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
-  int latency_bits;
-  if (-1 == ioctl(data->fd, TIOCGSERIAL, &latency_bits)) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
-    return;
-  }
-  data->lowLatency = latency_bits & ASYNC_LOW_LATENCY;
-  #endif
-
   data->cts = bits & TIOCM_CTS;
   data->dsr = bits & TIOCM_DSR;
   data->dcd = bits & TIOCM_CD;
+
+  #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
+  bool lowlatency = false;
+  if (-1 == linuxGetLowLatencyMode(data->fd, &lowlatency)) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get low latency", strerror(errno));
+    return;
+  }
+  data->lowLatency = lowlatency;
+  #else
+  data->lowLatency = false;
+  #endif
 }
 
 void EIO_GetBaudRate(uv_work_t* req) {


### PR DESCRIPTION
Fix for low latency mode:

### Changes

serialport_linux.cpp:
- Revise the linux set method to only attempt an update if required (if the bit doesn't need to be flipped then don't attempt an unnecessary call for which we might not have permission)
- Addition of a linux specific linuxGetLowLatencyMode method - for consistency with linuxGetSystemBaudRate, allowing removal of the logic from the more general unix code

serialport_linux.h:
- Addition of a linux specific linuxGetLowLatencyMode method - for consistency with linuxGetSystemBaudRate

serialport_unix.cpp:
- Revise sequence of set method - to allow control bits (e.g. dtr) to be set even if low latency fails
- Revise sequence of get method - to allow control bits (e.g. dtr) to be returned even if get of low latency info fails
- Revise get method to invoke linux specific method (point 2 above, and removing broken logic in the process)
- Revise the error messages for the set and get messages for the low latency calls to make it clearer when these fail - since they are likely to fail when we don't have suitable access rights

### Testing
Tested on Linux Ubuntu LTS and Win10:
- Linux without admin rights
  - Set method call {dtr: true} - succeeds without error
  - Set method call {dtr: true, lowLatency: true} - dtr correctly set, error reported for lowLatency, but handled without issue
  - Get method call - succeeds without error
- Linux with admin rights
  - Set method call {dtr: true} - succeeds without error
  - Set method call {dtr: true, lowLatency: true} - succeeds without error
  - Get method call - succeeds without error
- Windows 10
  - Set method call {dtr: true} - succeeds without error
  - Set method call {dtr: true, lowLatency: true} - succeeds without error (lowLatency ignored)
  - Get method call - succeeds without error

### Additional considerations
The the focus of this change was entirely on addressing errors per https://github.com/serialport/node-serialport/issues/2240 as such I have not performed any actual benchmarking of the lowLatency mode to check for changes to latency (or increases to CPU load - [setserial](https://linux.die.net/man/8/setserial) has info on expected benefits/impacts).
